### PR TITLE
replace lex-apollo extension reference with Legion::Apollo.ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # legion-mcp Changelog
 
+## [0.5.7] - 2026-03-25
+
+### Changed
+- `OverrideBroadcast#store_to_apollo` now routes through `Legion::Apollo.ingest` (core library) instead of calling `Legion::Extensions::Apollo::Runners::Knowledge.handle_ingest` directly — removes the hard coupling to the co-located extension
+
 ## [0.5.6] - 2026-03-24
 
 ### Changed

--- a/lib/legion/mcp/override_broadcast.rb
+++ b/lib/legion/mcp/override_broadcast.rb
@@ -44,15 +44,14 @@ module Legion
       end
 
       def store_to_apollo(tool:, lex:, confidence:, tests:, node:)
-        return unless defined?(Legion::Extensions::Apollo::Runners::Knowledge)
+        return unless defined?(Legion::Apollo) && Legion::Apollo.started?
 
-        Legion::Extensions::Apollo::Runners::Knowledge.handle_ingest(
+        Legion::Apollo.ingest(
           content:          "Override confirmed: #{tool} -> #{lex} (confidence: #{confidence}, tests: #{tests})",
-          content_type:     'fact',
           tags:             %w[override mesh_confirmed] + [tool],
-          source_agent:     "mesh:#{node}",
-          knowledge_domain: 'system',
-          context:          { tool: tool, lex: lex, confidence: confidence, tests: tests }
+          source_channel:   'mesh',
+          submitted_by:     "mesh:#{node}",
+          knowledge_domain: 'system'
         )
       rescue StandardError => e
         Legion::Logging.warn("OverrideBroadcast#store_to_apollo failed: #{e.message}") if defined?(Legion::Logging)

--- a/lib/legion/mcp/version.rb
+++ b/lib/legion/mcp/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module MCP
-    VERSION = '0.5.6'
+    VERSION = '0.5.7'
   end
 end

--- a/spec/legion/mcp/override_broadcast_spec.rb
+++ b/spec/legion/mcp/override_broadcast_spec.rb
@@ -58,6 +58,27 @@ RSpec.describe Legion::MCP::OverrideBroadcast do
     end
   end
 
+  describe '#store_to_apollo' do
+    context 'when Legion::Apollo is available' do
+      before do
+        stub_const('Legion::Apollo', double(started?: true, ingest: { success: true }))
+      end
+
+      it 'calls Legion::Apollo.ingest' do
+        described_class.send(:store_to_apollo, tool: 't', lex: 'l', confidence: 0.9, tests: 3, node: 'n1')
+        expect(Legion::Apollo).to have_received(:ingest)
+      end
+    end
+
+    context 'when Legion::Apollo is not available' do
+      it 'does not raise' do
+        expect do
+          described_class.send(:store_to_apollo, tool: 't', lex: 'l', confidence: 0.9, tests: 3, node: 'n1')
+        end.not_to raise_error
+      end
+    end
+  end
+
   describe '.receive_confirmation' do
     it 'boosts local confidence from remote confirmation' do
       confidence_stub.record(


### PR DESCRIPTION
## Summary
- `store_to_apollo` now uses `Legion::Apollo.ingest` instead of direct extension runner call
- Guarded by `defined?(Legion::Apollo) && Legion::Apollo.started?`

## Changes
- `lib/legion/mcp/override_broadcast.rb` — core library API reference
- 1 commit, version 0.5.6 → 0.5.7

## Test Coverage
- 587 examples, 0 failures
- `bundle exec rubocop` — zero offenses