### PR TITLE
remove legacy expose_as_mcp_tool fallback from function discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-03-28
+
+### Removed
+- Legacy `expose_as_mcp_tool` and `mcp_tool_prefix` fallback reads from `FunctionDiscovery#runner_expose_opts` — runners that do not use the definition DSL are no longer exposed; `class_expose` is always `nil` and `prefix` is always `nil` in the opts hash
+
 ## [0.6.4] - 2026-03-28
 
 ### Changed

--- a/lib/legion/mcp/function_discovery.rb
+++ b/lib/legion/mcp/function_discovery.rb
@@ -33,12 +33,9 @@ module Legion
         functions.each { |func_name, meta| register_function(runner_module, func_name, meta, opts) }
       end
 
-      def runner_expose_opts(runner_module)
-        # @deprecated class_expose/prefix — prefer definition DSL (mcp_exposed:, mcp_tool_prefix:)
-        class_expose = runner_module.respond_to?(:expose_as_mcp_tool) ? runner_module.expose_as_mcp_tool : nil
+      def runner_expose_opts(_runner_module)
         global_expose = defined?(Legion::Settings) ? (Legion::Settings.dig(:mcp, :auto_expose_runners) || false) : false
-        prefix = runner_module.respond_to?(:mcp_tool_prefix) ? runner_module.mcp_tool_prefix : nil
-        { class_expose: class_expose, global_expose: global_expose, prefix: prefix }
+        { class_expose: nil, global_expose: global_expose, prefix: nil }
       end
 
       def register_function(runner_module, func_name, meta, opts)

--- a/lib/legion/mcp/version.rb
+++ b/lib/legion/mcp/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module MCP
-    VERSION = '0.6.4'
+    VERSION = '0.6.5'
   end
 end

--- a/spec/legion/mcp/function_discovery_spec.rb
+++ b/spec/legion/mcp/function_discovery_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Legion::MCP::FunctionDiscovery do
         runner_module: Module.new { def self.my_func(**) = { success: true } },
         function_name: :my_func
       )
-      expect(klass).to be < ::MCP::Tool
+      expect(klass).to be < MCP::Tool
       expect(klass.tool_name).to eq('test.discovery_tool')
     end
 


### PR DESCRIPTION
## Summary
- Remove deprecated `expose_as_mcp_tool` / `mcp_tool_prefix` fallback path from MCP function discovery
- Tools now exclusively use the definition DSL for metadata

## Test plan
- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` passes