### PR TITLE
fix legion.do misrouting skills intent to swarm-github runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # legion-mcp Changelog
 
+## [0.8.1] - 2026-04-14
+
+### Fixed
+- `ContextCompiler::CATEGORIES` now includes a `:skills` category listing all four `legion.skill.*` tools (`legion.skill.list`, `legion.skill.describe`, `legion.skill.invoke`, `legion.skill.cancel`). Previously they were absent from `CATEGORIES` so `compressed_catalog` never surfaced them and `legion.do intent:"list all skills"` would misroute to an auto-discovered swarm-github runner, returning "missing keywords: :owner, :repo, :pull_number"
+- `ContextCompiler#keyword_score_map` now adds a +3 bonus per intent keyword that matches tool name terms (split on `.`), preventing semantic-score drift from lifting generic runner stubs above correctly-named skill tools when embeddings are active
+
 ## [0.8.0] - 2026-04-12
 
 ### Added

--- a/lib/legion/mcp/context_compiler.rb
+++ b/lib/legion/mcp/context_compiler.rb
@@ -71,6 +71,10 @@ module Legion
           tools:   %w[legion.eval_list legion.eval_run legion.eval_results],
           summary: 'Evaluation management - list evaluators, run evaluations, view results.'
         },
+        skills:        {
+          tools:   %w[legion.skill.list legion.skill.describe legion.skill.invoke legion.skill.cancel],
+          summary: 'Skill management - list, describe, invoke, and cancel LLM skills.'
+        },
         meta:          {
           tools:   %w[legion.do legion.tools legion.plan_action legion.structural_index],
           summary: 'Meta-tools - natural language routing, tool discovery, planning, structural index.'
@@ -214,6 +218,8 @@ module Legion
         tool_index.values.to_h do |entry|
           haystack = "#{entry[:name].downcase} #{entry[:description].downcase}"
           score = keywords.count { |kw| haystack.include?(kw) }
+          name_terms = entry[:name].downcase.tr('.', ' ').split
+          score += (keywords & name_terms).length * 3
           [entry[:name], score]
         end
       end

--- a/lib/legion/mcp/context_compiler.rb
+++ b/lib/legion/mcp/context_compiler.rb
@@ -218,7 +218,7 @@ module Legion
         tool_index.values.to_h do |entry|
           haystack = "#{entry[:name].downcase} #{entry[:description].downcase}"
           score = keywords.count { |kw| haystack.include?(kw) }
-          name_terms = entry[:name].downcase.tr('.', ' ').split
+          name_terms = entry[:name].downcase.tr('._-', ' ').split
           score += (keywords & name_terms).length * 3
           [entry[:name], score]
         end

--- a/lib/legion/mcp/version.rb
+++ b/lib/legion/mcp/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module MCP
-    VERSION = '0.8.0'
+    VERSION = '0.8.1'
   end
 end

--- a/spec/legion/mcp/context_compiler_spec.rb
+++ b/spec/legion/mcp/context_compiler_spec.rb
@@ -102,9 +102,33 @@ RSpec.describe Legion::MCP::ContextCompiler do
     end
   end
 
+  let(:stub_skill_list) do
+    Class.new(MCP::Tool) do
+      tool_name 'legion.skill.list'
+      description 'List all skills available in this Legion instance.'
+      input_schema(properties: {})
+    end
+  end
+
+  let(:stub_pr_reviewer) do
+    Class.new(MCP::Tool) do
+      tool_name 'legion-swarm_github-pull_request_reviewer-review_pull_request'
+      description 'swarm_github#review_pull_request'
+      input_schema(
+        properties: {
+          owner:       { type: 'string' },
+          repo:        { type: 'string' },
+          pull_number: { type: 'integer' }
+        },
+        required:   %w[owner repo pull_number]
+      )
+    end
+  end
+
   let(:stub_tool_classes) do
     [stub_run_task, stub_list_tasks, stub_get_task, stub_list_extensions,
-     stub_get_extension, stub_list_workers, stub_get_status, stub_rbac_check]
+     stub_get_extension, stub_list_workers, stub_get_status, stub_rbac_check,
+     stub_skill_list, stub_pr_reviewer]
   end
 
   before(:each) do
@@ -132,6 +156,19 @@ RSpec.describe Legion::MCP::ContextCompiler do
 
     it 'tasks category lists run_task' do
       expect(categories[:tasks][:tools]).to include('legion.run_task')
+    end
+
+    it 'contains a :skills category' do
+      expect(categories.keys).to include(:skills)
+    end
+
+    it 'skills category lists all four skill tools' do
+      expect(categories[:skills][:tools]).to include(
+        'legion.skill.list',
+        'legion.skill.describe',
+        'legion.skill.invoke',
+        'legion.skill.cancel'
+      )
     end
   end
 
@@ -260,6 +297,12 @@ RSpec.describe Legion::MCP::ContextCompiler do
     it 'returns nil when no keywords match' do
       result = described_class.match_tool('xyzzy florp quux')
       expect(result).to be_nil
+    end
+
+    it 'finds legion.skill.list for "list all skills", not the swarm-github pr reviewer' do
+      result = described_class.match_tool('list all skills')
+      expect(result).not_to be_nil
+      expect(result.tool_name).to eq('legion.skill.list')
     end
 
     it 'returns a class (not an instance)' do

--- a/spec/legion/mcp/tools/do_action_spec.rb
+++ b/spec/legion/mcp/tools/do_action_spec.rb
@@ -122,6 +122,45 @@ RSpec.describe Legion::MCP::Tools::DoAction do
       end
     end
 
+    context 'when matched tool has required params but none are provided' do
+      let(:tool_requiring_params) do
+        klass = Class.new(::MCP::Tool) do
+          tool_name 'legion.stub_required_params'
+          description 'stub tool with required params'
+          input_schema(
+            properties: {
+              owner:       { type: 'string' },
+              repo:        { type: 'string' },
+              pull_number: { type: 'integer' }
+            },
+            required:   %w[owner repo pull_number]
+          )
+        end
+        allow(klass).to receive(:call).and_raise(ArgumentError, 'missing keywords: :owner, :repo, :pull_number')
+        klass
+      end
+
+      before do
+        allow(Legion::MCP::ContextCompiler).to receive(:match_tool).and_return(tool_requiring_params)
+      end
+
+      it 'returns an error response instead of propagating ArgumentError' do
+        response = described_class.call(intent: 'review pull request')
+        expect(response).to be_a(MCP::Tool::Response)
+        expect(response.error?).to be true
+      end
+
+      it 'includes the missing param names in the error message' do
+        response = described_class.call(intent: 'review pull request')
+        data = Legion::JSON.load(response.content.first[:text])
+        expect(data[:error]).to include('owner', 'repo', 'pull_number')
+      end
+
+      it 'does not raise ArgumentError to the caller' do
+        expect { described_class.call(intent: 'review pull request') }.not_to raise_error
+      end
+    end
+
     describe 'observer feedback' do
       before do
         Legion::MCP::Observer.reset!


### PR DESCRIPTION
## Summary

Fixes #33.

- **Add `:skills` category to `ContextCompiler::CATEGORIES`** — `legion.skill.list`, `.describe`, `.invoke`, `.cancel` were registered in `MCP_SPECIFIC_TOOLS` but absent from `CATEGORIES`, so `compressed_catalog` never surfaced them and `match_tool` had no category signal to prefer them
- **Boost keyword name-match scoring** — add +3 per intent keyword that appears in the tool name terms (split on `.`), so `legion.skill.list` scores above generic auto-discovered runner stubs when embeddings are ambiguous
- **Regression specs** — `CATEGORIES` must include `:skills` with all four tools; `match_tool("list all skills")` must return `legion.skill.list` even when a `swarm-github` runner stub is in the registry; missing required params must return an error response

## Test plan

- [ ] `bundle exec rspec` — 0 failures
- [ ] `bundle exec rubocop` — 0 offenses
- [ ] Manually: call `legion.do intent:"list all skills"` against local daemon — should return skill list, not "missing keywords: :owner, :repo, :pull_number"